### PR TITLE
feat: insecure cookie serving through flag

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,5 +1,7 @@
 Xlog is designed to be accessed by trusted clients inside trusted environments. This means that usually it is not a good idea to expose the Xlog instance directly to the internet or, in general, to an environment where untrusted clients can directly access the Xlog TCP port.
 
+If you want to expose it over unsecure HTTP (for development purposes or in LAN), please use `--serve-insecure true` flag.
+
 # Listening on specific network interface
 
 Xlog accepts `--bind` flag that defines the interface which xlog should listen to. `--bind` is in the format `<ip.address.of.interface>:<port>`. 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -34,6 +34,10 @@ Usage of xlog:
         RSS domain name to be used for RSS feed. without HTTPS://
   -rss.limit int
         Limit the number of items in the RSS feed to this amount (default 30)
+  -serve-insecure
+        Accept http connections and forward crsf cookie over non secure connections
+  -sidebar
+        Should render sidebar. (default true)
   -sitemap.domain string
         domain name without protocol or trailing / to use for sitemap loc
   -sitename string

--- a/server.go
+++ b/server.go
@@ -43,10 +43,7 @@ func defaultMiddlewares() []func(http.Handler) http.Handler {
 		csrf.Path("/"),
 		csrf.FieldName("csrf"),
 		csrf.CookieName(xCSRF_COOKIE_NAME),
-	}
-
-	if serveInsecure == true {
-		crsfOpts = append(crsfOpts, csrf.Secure(false))
+		csrf.Secure(!serveInsecure),
 	}
 
 	middlewares := []func(http.Handler) http.Handler{

--- a/server.go
+++ b/server.go
@@ -17,24 +17,14 @@ import (
 const xCSRF_COOKIE_NAME = "xlog_csrf"
 
 var (
-	bind_address string
-	router       = &mux{}
+	bindAddress   string
+	serveInsecure bool
+	router        = &mux{}
 	// a function that renders CSRF hidden input field
 	CSRF = csrf.TemplateField
 
 	dynamicSegmentWithPatternRegexp = regexp.MustCompile("{([^}]+):([^}]+)}")
 	dynamicSegmentRegexp            = regexp.MustCompile("{([^}]+)}")
-	middlewares                     = []func(http.Handler) http.Handler{
-		methodOverrideHandler,
-		csrf.Protect(
-			[]byte(os.Getenv("SESSION_SECRET")),
-			csrf.Path("/"),
-			csrf.FieldName("csrf"),
-			csrf.CookieName(xCSRF_COOKIE_NAME),
-			csrf.Secure(false),
-		),
-		requestLoggerHandler,
-	}
 )
 
 type (
@@ -48,26 +38,47 @@ type (
 	Locals map[string]interface{} // passed to templates
 )
 
+func defaultMiddlewares() []func(http.Handler) http.Handler {
+	crsfOpts := []csrf.Option{
+		csrf.Path("/"),
+		csrf.FieldName("csrf"),
+		csrf.CookieName(xCSRF_COOKIE_NAME),
+	}
+
+	if serveInsecure == true {
+		crsfOpts = append(crsfOpts, csrf.Secure(false))
+	}
+
+	middlewares := []func(http.Handler) http.Handler{
+		methodOverrideHandler,
+		csrf.Protect([]byte(os.Getenv("SESSION_SECRET")), crsfOpts...),
+		requestLoggerHandler,
+	}
+
+	return middlewares
+}
+
 func init() {
-	flag.StringVar(&bind_address, "bind", "127.0.0.1:3000", "IP and port to bind the web server to")
+	flag.StringVar(&bindAddress, "bind", "127.0.0.1:3000", "IP and port to bind the web server to")
+	flag.BoolVar(&serveInsecure, "serve-insecure", false, "Accept http connections and forward crsf cookie over non secure connections")
 }
 
 func serve() {
 	srv := server()
-	log.Printf("Starting server: %s", bind_address)
+	log.Printf("Starting server: %s", bindAddress)
 	log.Fatal(srv.ListenAndServe())
 }
 
 func server() *http.Server {
 	compileTemplates()
 	var handler http.Handler = router
-	for _, v := range middlewares {
+	for _, v := range defaultMiddlewares() {
 		handler = v(handler)
 	}
 
 	return &http.Server{
 		Handler:      handler,
-		Addr:         bind_address,
+		Addr:         bindAddress,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}


### PR DESCRIPTION
as per https://github.com/emad-elsaid/xlog/discussions/17

@emad-elsaid In addition: while I agree about the security concerns you raised in the discussion, as of now to host xlog over https requires a proxy.
It could be a good addition to use https://pkg.go.dev/net/http#Server.ListenAndServeTLS with a cert file so to avoid the proxy.
