### PR TITLE
jumpt to last position

### DIFF
--- a/extensions/hotreload/hotreload.go
+++ b/extensions/hotreload/hotreload.go
@@ -86,9 +86,16 @@ const clientScript = `
         let socket = new WebSocket(socketUrl);
         socket.addEventListener('message', (evt) => {
             let data = JSON.parse(evt.data)
+  			sessionStorage.setItem('scrollPosition', window.scrollY);
             window.location.href = data.url;
         });
     })();
+    window.addEventListener('load', function() {
+    	const scrollPosition = sessionStorage.getItem('scrollPosition');
+    	if (scrollPosition !== null) {
+    		window.scrollTo(0, parseInt(scrollPosition, 10));
+    	}
+    });
     </script>
     `
 


### PR DESCRIPTION
Small addon to the hotreload extension: now it jumps to the last position in page. Otherwise, when editing a page, the page was reloaded, but put on the beginning of the page, needing to scroll down again..