### PR TITLE
Fix backlinks

### DIFF
--- a/extensions/autolink_pages/autolink_pages.go
+++ b/extensions/autolink_pages/autolink_pages.go
@@ -64,10 +64,8 @@ func backlinksSection(p Page) template.HTML {
 		return ""
 	}
 
-	// log.Printf("backlink from %s", p.Name())
 	pages := MapPageCon(context.Background(), func(a Page) *Page {
 		_, tree := a.AST()
-		// log.Printf("visiting %s from %s", a.FileName(), p.FileName())
 		if a.Name() == p.Name() || !containLinkTo(tree, p) {
 			return nil
 		}
@@ -81,14 +79,12 @@ func backlinksSection(p Page) template.HTML {
 func containLinkTo(n ast.Node, p Page) bool {
 	if n.Kind() == KindPageLink {
 		t, _ := n.(*PageLink)
-		// log.Printf("link %s", t.page.FileName())
 		if t.page.FileName() == p.FileName() {
 			return true
 		}
 	}
 	if n.Kind() == ast.KindLink {
 		t, _ := n.(*ast.Link)
-		// log.Printf("link %s", t.Destination)
 		dst := string(t.Destination)
 
 		// link is absolute: remove /


### PR DESCRIPTION
And the last pull request for today :) The backlinks section only list links from the online editor, this changes add support for normal links (made directly in markdown).
But there still one thing (and the problem is related to #61, where we have are directories). We have following scenario:
```
dir-1/
  - file-a.md
  - file-b.md
 dir-2/
  - file-b.md
 ```
Now, `file-a` could link to `file-b` in the following ways: `/dir-1/file-b` or `file-b`. Both valid links, but on the last link, there is no way to differentiate if the link is coming from `dir-1` or `dir-2`. For now, i just ignore it. Do you have any ideas?