### PR TITLE
link_preview.go: fix Twitter regexp

### DIFF
--- a/extensions/link_preview/link_preview.go
+++ b/extensions/link_preview/link_preview.go
@@ -37,7 +37,7 @@ func imgUrlPreprocessor(c Markdown) Markdown {
 	return Markdown(imgUrlReg.ReplaceAllString(string(c), `![]($1)`))
 }
 
-var tweetUrlReg = regexp.MustCompile(`(?imU)^(https\:\/\/twitter.com\/[^ ]+\/status\/[0-9]+)$`)
+var tweetUrlReg = regexp.MustCompile(`(?imU)^(https\:\/\/twitter\.com\/[^ ]+\/status\/[0-9]+)$`)
 
 func tweetUrlPreprocessor(c Markdown) Markdown {
 	return Markdown(


### PR DESCRIPTION
This commit fixes the Twitter regex by escaping a dot in `.com`.

[Before:](https://regexper.com/#%5E%28https%5C%3A%5C%2F%5C%2Ftwitter.com%5C%2F%5B%5E%20%5D%2B%5C%2Fstatus%5C%2F%5B0-9%5D%2B%29%24)
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/846a6f2f-9f90-4411-9b49-e995a0c5523e">

[After:](https://regexper.com/#%5E%28https%5C%3A%5C%2F%5C%2Ftwitter%5C.com%5C%2F%5B%5E%20%5D%2B%5C%2Fstatus%5C%2F%5B0-9%5D%2B%29%24)
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/7e31df06-8b8e-4a18-b98f-1154f8bb019a">
