### PR TITLE
Fix images paths in several situations related to pages in subdirs

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"path"
 	"slices"
 	"strings"
 	"time"
@@ -160,7 +161,17 @@ func Banner(p Page) string {
 		return ""
 	}
 
-	return string(image.Destination)
+	dest := string(image.Destination)
+	if len(dest) == 0 || dest == "#" {
+		return ""
+	}
+
+	if !(path.IsAbs(dest) || strings.HasPrefix(dest, "http")) {
+		d := path.Dir(p.FileName())
+		dest = path.Join("/", d, dest)
+	}
+
+	return dest
 }
 
 func Emoji(p Page) string {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,75 @@
+package xlog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestBanner(t *testing.T) {
+	tcs := []struct {
+		name     string
+		path     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "page in root and image is relative implicitly",
+			path:     "home",
+			content:  "![](image.jpg)",
+			expected: "/image.jpg",
+		},
+		{
+			name:     "page in root and image is relative explicitly",
+			path:     "home",
+			content:  "![](./image.jpg)",
+			expected: "/image.jpg",
+		},
+		{
+			name:     "page in root and image is relative explicitly in subdir",
+			path:     "home",
+			content:  "![](./images/image.jpg)",
+			expected: "/images/image.jpg",
+		},
+		{
+			name:     "page in subdir and image is relative implicitly",
+			path:     "posts/home",
+			content:  "![](image.jpg)",
+			expected: "/posts/image.jpg",
+		},
+		{
+			name:     "page in subdir and image is relative explicitly",
+			path:     "posts/home",
+			content:  "![](./image.jpg)",
+			expected: "/posts/image.jpg",
+		},
+		{
+			name:     "page in subdir and image is relative explicitly in subdir",
+			path:     "posts/home",
+			content:  "![](./images/image.jpg)",
+			expected: "/posts/images/image.jpg",
+		},
+		{
+			name:     "page in subdir and image is relative explicitly in parent",
+			path:     "posts/home",
+			content:  "![](../images/image.jpg)",
+			expected: "/images/image.jpg",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := text.NewReader([]byte(tc.content))
+			p := page{
+				name:       tc.path,
+				lastUpdate: time.Time{},
+				ast:        MarkdownConverter().Parser().Parse(reader),
+				content:    (*Markdown)(&tc.content),
+			}
+
+			require.Equal(t, tc.expected, Banner(&p))
+		})
+	}
+}


### PR DESCRIPTION
* Images in pages in subdirectories with relative path will not be displayed correctly in pages lists as the relative path won't be correct. this fixes it by converting any banner image to absolute path relative to the page is came from

![2025-02-09_14-54-44](https://github.com/user-attachments/assets/df61a552-9a5f-40e0-8880-9c68062b59f6)
![2025-02-09_14-25-51](https://github.com/user-attachments/assets/567542ce-9f87-4fd4-8276-6bcf5577a2ae)

