### PR TITLE
Use page emoji as favicon

### DIFF
--- a/templates/emoji-favicon.html
+++ b/templates/emoji-favicon.html
@@ -1,0 +1,32 @@
+<script>
+ // after rendering the page if remove the emoji from title and replace the page icon with it
+ function setEmojiAsFavicon(emoji) {
+     // Remove emoji from page title if exists
+     document.title = document.title.replace(/^[\p{Emoji}\s]+/u, '').trim();
+
+     // Create a canvas to draw the emoji
+     const canvas = document.createElement('canvas');
+     canvas.width = 16;
+     canvas.height = 16;
+     const ctx = canvas.getContext('2d');
+
+     // Draw emoji, centered and scaled with transparent background
+     ctx.font = '16px serif';
+     ctx.textAlign = 'center';
+     ctx.textBaseline = 'middle';
+     ctx.fillText(emoji, 8, 10);
+
+     // Convert canvas to favicon
+     const link = document.querySelector("link[rel~='icon']") || document.createElement('link');
+     link.type = 'image/x-icon';
+     link.rel = 'shortcut icon';
+     link.href = canvas.toDataURL();
+
+     // Append to head if not already there
+     if (!document.querySelector("link[rel~='icon']")) {
+         document.head.appendChild(link);
+     }
+ }
+
+ setEmojiAsFavicon('{{.}}')
+</script>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -18,6 +18,12 @@
       {{.config.Sitename}}
     </title>
     {{- with .page }} {{ widgets "head" . }} {{ end }}
+
+    {{- with .page -}}
+    {{- if ne .Name $.config.Index -}}
+    {{ with emoji . }}{{ template "emoji-favicon" . }}{{ end }}
+    {{- end -}}
+    {{- end -}}
   </head>
   <body>
     {{- template "commands" . -}}


### PR DESCRIPTION
This will get the page emoji if exists and replace the favicon with it and remove the emoji from the title. 

This is useful if you're using multi tab, the icon will be the tab icon and you can choose whatever emoji you want to each page. 

## to disable this feature
* create an empty file in `theme/emoji-favicon.html` in your website. this will override `templates/emoji-favicon.html` template