### PR TITLE
Fix emoji place in the title for pages in subdirs

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -34,13 +34,13 @@
       {{- if ne .config.Index .page.Name -}}
       <div dir="auto" class="title is-1 has-text-weight-bold" style="view-transition-name: page-title;">
         {{- with .page -}}
-        {{- emoji . }}
-        {{ with $props.title }}
-          {{ .Value }}
-        {{ else }}
-          {{ with dir .Name }}<p class="subtitle">{{.}}</p>{{ end }}
-          {{ base .Name }}
-        {{ end }}
+          {{ with $props.title }}
+            {{- emoji . }}
+            {{ .Value }}
+          {{ else }}
+            {{ with dir .Name }}<p class="subtitle">{{.}}</p>{{ end }}
+            {{- emoji . }} {{ base .Name }}
+          {{ end }}
         {{- end -}}
       </div>
       {{- end -}}


### PR DESCRIPTION
- For pages in subdirectories the emoji was places on top of the directory name instead of beside the title, this fixes it to move the emoji beside the title