### PR TITLE
Add wiki link preprocessor extension

### DIFF
--- a/docs/Features Test.md
+++ b/docs/Features Test.md
@@ -37,7 +37,7 @@ For example, xlog has templates defined inside `templates/` one of them is `page
 | Subscript                                       | `<sub>`                      | X<sub>2</sub>                                  |
 | Superscript                                     | `<sup>`                      | X<sup>2</sup>                                  |
 | Linking                                         | `[text](url)`                | [Emad Elsaid](https://www.emadelsaid.com)      |
-| Wiki-style linking                              | `[[Page Name]]`              | [[index]], [[Features Test]]                   |
+| Wiki-style linking                              | `\[[Page Name]]`             | [[index]], [[Features Test]]                   |
 | Shorting Long URLs:                             |                              | https://en.wikipedia.org/wiki/Computer_science |
 | Auto linking text if it's a page name           |                              | index, Features Test                           |
 | Emoji                                           | `:EMOJICODE:`                | :wrench:                                       |

--- a/docs/Features Test.md
+++ b/docs/Features Test.md
@@ -37,6 +37,7 @@ For example, xlog has templates defined inside `templates/` one of them is `page
 | Subscript                                       | `<sub>`                      | X<sub>2</sub>                                  |
 | Superscript                                     | `<sup>`                      | X<sup>2</sup>                                  |
 | Linking                                         | `[text](url)`                | [Emad Elsaid](https://www.emadelsaid.com)      |
+| Wiki-style linking                              | `[[Page Name]]`              | [[index]], [[Features Test]]                   |
 | Shorting Long URLs:                             |                              | https://en.wikipedia.org/wiki/Computer_science |
 | Auto linking text if it's a page name           |                              | index, Features Test                           |
 | Emoji                                           | `:EMOJICODE:`                | :wrench:                                       |

--- a/extensions/all/all.go
+++ b/extensions/all/all.go
@@ -37,4 +37,5 @@ import (
 	_ "github.com/emad-elsaid/xlog/extensions/toc"
 	_ "github.com/emad-elsaid/xlog/extensions/todo"
 	_ "github.com/emad-elsaid/xlog/extensions/upload_file"
+	_ "github.com/emad-elsaid/xlog/extensions/wikilink"
 )

--- a/extensions/wikilink/wikilink.go
+++ b/extensions/wikilink/wikilink.go
@@ -1,0 +1,44 @@
+package wikilink
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/emad-elsaid/xlog"
+)
+
+const extensionName = "wikilink"
+
+// Pattern to match wiki links: [[Page Name]] or [[Subdirectory/Page Name]].
+var wikiLinkRegex = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+
+func init() {
+	xlog.RegisterExtension(WikiLink{})
+}
+
+type WikiLink struct{}
+
+func (WikiLink) Name() string { return extensionName }
+func (WikiLink) Init() {
+	xlog.RegisterPreprocessor(preprocessor)
+}
+
+// preprocessor converts [[Page Name]] syntax to markdown links [Page Name](/Page_Name).
+func preprocessor(md xlog.Markdown) xlog.Markdown {
+	content := string(md)
+
+	// Replace all wiki links with markdown links
+	result := wikiLinkRegex.ReplaceAllStringFunc(content, func(match string) string {
+		// Extract the page name from [[Page Name]]
+		pageName := strings.TrimSpace(match[2 : len(match)-2])
+
+		// Convert page name to URL path
+		// Replace spaces with underscores for URL compatibility
+		urlPath := strings.ReplaceAll(pageName, " ", "_")
+
+		// Create markdown link: [Display Name](/URL_Path)
+		return "[" + pageName + "](/" + urlPath + ")"
+	})
+
+	return xlog.Markdown(result)
+}

--- a/extensions/wikilink/wikilink.go
+++ b/extensions/wikilink/wikilink.go
@@ -10,7 +10,8 @@ import (
 const extensionName = "wikilink"
 
 // Pattern to match wiki links: [[Page Name]] or [[Subdirectory/Page Name]].
-var wikiLinkRegex = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+// Also matches escaped wiki links: \[[Page Name]].
+var wikiLinkRegex = regexp.MustCompile(`\\?\[\[([^\]]+)\]\]`)
 
 func init() {
 	xlog.RegisterExtension(WikiLink{})
@@ -24,11 +25,18 @@ func (WikiLink) Init() {
 }
 
 // preprocessor converts [[Page Name]] syntax to markdown links [Page Name](/Page_Name).
+// Escaped syntax \[[Page Name]] is left as literal [[Page Name]] (backslash removed).
 func preprocessor(md xlog.Markdown) xlog.Markdown {
 	content := string(md)
 
 	// Replace all wiki links with markdown links
 	result := wikiLinkRegex.ReplaceAllStringFunc(content, func(match string) string {
+		// Check if this is an escaped wiki link (starts with backslash)
+		if strings.HasPrefix(match, `\`) {
+			// Remove the escape backslash, leave the rest as-is
+			return match[1:]
+		}
+
 		// Extract the page name from [[Page Name]]
 		pageName := strings.TrimSpace(match[2 : len(match)-2])
 

--- a/extensions/wikilink/wikilink_test.go
+++ b/extensions/wikilink/wikilink_test.go
@@ -1,0 +1,117 @@
+package wikilink
+
+import (
+	"testing"
+
+	"github.com/emad-elsaid/xlog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreprocessor(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    xlog.Markdown
+		expected xlog.Markdown
+	}{
+		{
+			name:     "simple wiki link",
+			input:    "Check out [[Home]]",
+			expected: "Check out [Home](/Home)",
+		},
+		{
+			name:     "wiki link with spaces",
+			input:    "Learn about [[Machine Learning]]",
+			expected: "Learn about [Machine Learning](/Machine_Learning)",
+		},
+		{
+			name:     "wiki link with subdirectory",
+			input:    "See [[docs/Installation]]",
+			expected: "See [docs/Installation](/docs/Installation)",
+		},
+		{
+			name:     "multiple wiki links",
+			input:    "[[Home]] and [[About]] pages",
+			expected: "[Home](/Home) and [About](/About) pages",
+		},
+		{
+			name:     "wiki link in sentence",
+			input:    "I'm learning about [[Neural Networks]] and [[Machine Learning]].",
+			expected: "I'm learning about [Neural Networks](/Neural_Networks) and [Machine Learning](/Machine_Learning).",
+		},
+		{
+			name:     "no wiki links",
+			input:    "This is plain text with [regular](link)",
+			expected: "This is plain text with [regular](link)",
+		},
+		{
+			name:     "wiki link with special characters",
+			input:    "[[C++ Programming]]",
+			expected: "[C++ Programming](/C++_Programming)",
+		},
+		{
+			name:     "empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "wiki link at start and end",
+			input:    "[[Start]] middle [[End]]",
+			expected: "[Start](/Start) middle [End](/End)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := preprocessor(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestWikiLinkRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single match",
+			input:    "[[Page]]",
+			expected: []string{"Page"},
+		},
+		{
+			name:     "multiple matches",
+			input:    "[[First]] and [[Second]]",
+			expected: []string{"First", "Second"},
+		},
+		{
+			name:     "no matches",
+			input:    "No wiki links here",
+			expected: []string{},
+		},
+		{
+			name:     "nested brackets not matched",
+			input:    "[[[Invalid]]]",
+			expected: []string{"[Invalid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := wikiLinkRegex.FindAllStringSubmatch(tc.input, -1)
+			var results []string
+			for _, match := range matches {
+				if len(match) > 1 {
+					results = append(results, match[1])
+				}
+			}
+			if tc.expected == nil {
+				tc.expected = []string{}
+			}
+			if results == nil {
+				results = []string{}
+			}
+			assert.Equal(t, tc.expected, results)
+		})
+	}
+}

--- a/extensions/wikilink/wikilink_test.go
+++ b/extensions/wikilink/wikilink_test.go
@@ -58,6 +58,21 @@ func TestPreprocessor(t *testing.T) {
 			input:    "[[Start]] middle [[End]]",
 			expected: "[Start](/Start) middle [End](/End)",
 		},
+		{
+			name:     "escaped wiki link with backslash",
+			input:    `\[[Page Name]]`,
+			expected: "[[Page Name]]",
+		},
+		{
+			name:     "mixed escaped and unescaped",
+			input:    `\[[Escaped]] and [[Not Escaped]]`,
+			expected: "[[Escaped]] and [Not Escaped](/Not_Escaped)",
+		},
+		{
+			name:     "escaped in code description",
+			input:    `Use \[[Page Name]] to link`,
+			expected: "Use [[Page Name]] to link",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Implements wiki-style linking syntax `[[Page Name]]` that converts to markdown links during preprocessing.

## Changes

- **New extension**: `extensions/wikilink/` with preprocessor implementation
- **Registration**: Added to `extensions/all/all.go` for automatic loading
- **Conversion logic**: Transforms `[[Page Name]]` → `[Page Name](/Page_Name)`
- **Space handling**: Replaces spaces with underscores for URL compatibility
- **Path support**: Handles subdirectory paths like `[[docs/Installation]]`

## Testing

- Comprehensive table-driven tests covering:
  - Simple wiki links
  - Links with spaces
  - Subdirectory paths
  - Multiple links in same content
  - Special characters
  - Edge cases (empty content, no links)
- All existing tests pass with race detector
- Linter passes with no issues

## Implementation Details

Follows established patterns from existing extensions:
- Uses `RegisterPreprocessor()` for content transformation
- Regex pattern matching for `[[...]]` syntax
- Minimal, focused implementation
- Proper initialization in `init()`

This addresses the gap identified in the codebase where wiki links were recognized for
analysis (backlinks, stats) but not actually rendered as clickable links.